### PR TITLE
migrate bigdl-llm to ipex-llm

### DIFF
--- a/docs/docs/integrations/llms/ipex_llm.ipynb
+++ b/docs/docs/integrations/llms/ipex_llm.ipynb
@@ -4,11 +4,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# BigDL-LLM\n",
+    "# IPEX-LLM\n",
     "\n",
-    "> [BigDL-LLM](https://github.com/intel-analytics/BigDL/) is a low-bit LLM optimization library on Intel XPU (Xeon/Core/Flex/Arc/Max). It can make LLMs run extremely fast and consume much less memory on Intel platforms. It is open sourced under Apache 2.0 License.\n",
+    "> [IPEX-LLM](https://github.com/intel-analytics/ipex-llm/) is a low-bit LLM optimization library on Intel XPU (Xeon/Core/Flex/Arc/Max). It can make LLMs run extremely fast and consume much less memory on Intel platforms. It is open sourced under Apache 2.0 License.\n",
     "\n",
-    "This example goes over how to use LangChain to interact with BigDL-LLM for text generation. \n"
+    "This example goes over how to use LangChain to interact with IPEX-LLM for text generation. \n"
    ]
   },
   {
@@ -33,7 +33,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Install BigDL-LLM for running LLMs locally on Intel CPU."
+    "Install IEPX-LLM for running LLMs locally on Intel CPU."
    ]
   },
   {
@@ -42,8 +42,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Install BigDL\n",
-    "%pip install --pre --upgrade bigdl-llm[all]"
+    "%pip install --pre --upgrade ipex-llm[all]"
    ]
   },
   {
@@ -60,7 +59,7 @@
    "outputs": [],
    "source": [
     "from langchain.chains import LLMChain\n",
-    "from langchain_community.llms.bigdl import BigdlLLM\n",
+    "from langchain_community.llms.ipex_llm import IPEXLLM\n",
     "from langchain_core.prompts import PromptTemplate"
    ]
   },
@@ -110,7 +109,7 @@
     }
    ],
    "source": [
-    "llm = BigdlLLM.from_model_id(\n",
+    "llm = IPEXLLM.from_model_id(\n",
     "    model_id=\"lmsys/vicuna-7b-v1.5\",\n",
     "    model_kwargs={\"temperature\": 0, \"max_length\": 64, \"trust_remote_code\": True},\n",
     ")"

--- a/docs/docs/integrations/llms/ipex_llm.ipynb
+++ b/docs/docs/integrations/llms/ipex_llm.ipynb
@@ -88,7 +88,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "69e018750ffb4de1af22ce49cd6957f4",
+       "model_id": "fc4d9eddb1d04f1897e2d09919ceacc1",
        "version_major": 2,
        "version_minor": 0
       },
@@ -103,8 +103,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2024-02-23 18:10:22,896 - INFO - Converting the current model to sym_int4 format......\n",
-      "2024-02-23 18:10:25,415 - INFO - BIGDL_OPT_IPEX: False\n"
+      "2024-03-26 06:50:44,210 - INFO - Converting the current model to sym_int4 format......\n"
      ]
     }
    ],
@@ -124,16 +123,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/anaconda3/envs/shane-langchain2/lib/python3.9/site-packages/langchain_core/_api/deprecation.py:117: LangChainDeprecationWarning: The function `run` was deprecated in LangChain 0.1.0 and will be removed in 0.2.0. Use invoke instead.\n",
-      "  warn_deprecated(\n",
       "/opt/anaconda3/envs/shane-langchain2/lib/python3.9/site-packages/transformers/generation/utils.py:1369: UserWarning: Using `max_length`'s default (4096) to control the generation length. This behaviour is deprecated and will be removed from the config in v5 of Transformers -- we recommend using `max_new_tokens` to control the maximum length of the generation.\n",
+      "  warnings.warn(\n",
+      "/opt/anaconda3/envs/shane-langchain2/lib/python3.9/site-packages/ipex_llm/transformers/models/llama.py:218: UserWarning: Passing `padding_mask` is deprecated and will be removed in v4.37.Please make sure use `attention_mask` instead.`\n",
       "  warnings.warn(\n"
      ]
     },
@@ -141,10 +140,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
-      "To disable this warning, you can either:\n",
-      "\t- Avoid using `tokenizers` before the fork if possible\n",
-      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n",
       "AI stands for \"Artificial Intelligence.\" It refers to the development of computer systems that can perform tasks that typically require human intelligence, such as visual perception, speech recognition, decision-making, and language translation. AI can be achieved through a combination of techniques such as machine learning, natural language processing, computer vision, and robotics. The ultimate goal of AI research is to create machines that can think and learn like humans, and can even exceed human capabilities in certain areas.\n"
      ]
     }
@@ -155,6 +150,13 @@
     "question = \"What is AI?\"\n",
     "output = llm_chain.run(question)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/libs/community/langchain_community/llms/ipex_llm.py
+++ b/libs/community/langchain_community/llms/ipex_llm.py
@@ -109,7 +109,7 @@ class IPEXLLM(LLM):
 
         Args:
 
-            model_id: Path for the ipex-llm transformers low-bit model checkpoint folder.
+            model_id: Path for the ipex-llm transformers low-bit model folder.
             model_kwargs: Keyword arguments to pass to the model and tokenizer.
             kwargs: Extra arguments to pass to the model and tokenizer.
 

--- a/libs/community/langchain_community/llms/ipex_llm.py
+++ b/libs/community/langchain_community/llms/ipex_llm.py
@@ -10,14 +10,14 @@ DEFAULT_MODEL_ID = "gpt2"
 logger = logging.getLogger(__name__)
 
 
-class BigdlLLM(LLM):
-    """Wrapper around the BigDL-LLM Transformer-INT4 model
+class IPEXLLM(LLM):
+    """Wrapper around the IPEX-LLM model
 
     Example:
         .. code-block:: python
 
-            from langchain.llms import TransformersLLM
-            llm = TransformersLLM.from_model_id(model_id="THUDM/chatglm-6b")
+            from langchain.llms import IPEXLLM
+            llm = IPEXLLM.from_model_id(model_id="THUDM/chatglm-6b")
     """
 
     model_id: str = DEFAULT_MODEL_ID
@@ -25,7 +25,7 @@ class BigdlLLM(LLM):
     model_kwargs: Optional[dict] = None
     """Keyword arguments passed to the model."""
     model: Any  #: :meta private:
-    """BigDL-LLM Transformers-INT4 model."""
+    """IPEXLLM model."""
     tokenizer: Any  #: :meta private:
     """Huggingface tokenizer model."""
     streaming: bool = True
@@ -56,7 +56,7 @@ class BigdlLLM(LLM):
             An object of TransformersLLM.
         """
         try:
-            from bigdl.llm.transformers import (
+            from ipex_llm.transformers import (
                 AutoModel,
                 AutoModelForCausalLM,
             )
@@ -64,8 +64,8 @@ class BigdlLLM(LLM):
 
         except ImportError:
             raise ValueError(
-                "Could not import bigdl-llm or transformers. "
-                "Please install it with `pip install --pre --upgrade bigdl-llm[all]`."
+                "Could not import ipex_llm or transformers. "
+                "Please install it with `pip install --pre --upgrade ipex_llm[all]`."
             )
 
         _model_kwargs = model_kwargs or {}
@@ -109,7 +109,7 @@ class BigdlLLM(LLM):
 
         Args:
 
-            model_id: Path for the bigdl transformers low-bit model checkpoint folder.
+            model_id: Path for the ipex-llm transformers low-bit model checkpoint folder.
             model_kwargs: Keyword arguments to pass to the model and tokenizer.
             kwargs: Extra arguments to pass to the model and tokenizer.
 
@@ -117,7 +117,7 @@ class BigdlLLM(LLM):
             An object of TransformersLLM.
         """
         try:
-            from bigdl.llm.transformers import (
+            from ipex_llm.transformers import (
                 AutoModel,
                 AutoModelForCausalLM,
             )
@@ -125,8 +125,8 @@ class BigdlLLM(LLM):
 
         except ImportError:
             raise ValueError(
-                "Could not import bigdl-llm or transformers. "
-                "Please install it with `pip install --pre --upgrade bigdl-llm[all]`"
+                "Could not import ipex_llm or transformers. "
+                "Please install it with `pip install --pre --upgrade ipex_llm[all]`"
             )
 
         _model_kwargs = model_kwargs or {}
@@ -163,7 +163,7 @@ class BigdlLLM(LLM):
 
     @property
     def _llm_type(self) -> str:
-        return "BigDL-llm"
+        return "ipex-llm"
 
     def _call(
         self,

--- a/libs/community/tests/integration_tests/llms/test_ipex_llm.py
+++ b/libs/community/tests/integration_tests/llms/test_ipex_llm.py
@@ -1,12 +1,12 @@
-"""Test BigDL LLM"""
+"""Test IPEX LLM"""
 from langchain_core.outputs import LLMResult
 
-from langchain_community.llms.bigdl import BigdlLLM
+from langchain_community.llms.ipex_llm import IPEXLLM
 
 
 def test_call() -> None:
-    """Test valid call to baichuan."""
-    llm = BigdlLLM.from_model_id(
+    """Test valid call to ipex-llm."""
+    llm = IPEXLLM.from_model_id(
         model_id="lmsys/vicuna-7b-v1.5",
         model_kwargs={"temperature": 0, "max_length": 16, "trust_remote_code": True},
     )
@@ -15,8 +15,8 @@ def test_call() -> None:
 
 
 def test_generate() -> None:
-    """Test valid call to baichuan."""
-    llm = BigdlLLM.from_model_id(
+    """Test valid call to ipex-llm."""
+    llm = IPEXLLM.from_model_id(
         model_id="lmsys/vicuna-7b-v1.5",
         model_kwargs={"temperature": 0, "max_length": 16, "trust_remote_code": True},
     )


### PR DESCRIPTION
- Description:  `bigdl-llm` library has been renamed to [`ipex-llm`](https://github.com/intel-analytics/ipex-llm). This PR migrates the `bigdl-llm` integration to `ipex-llm` .
- Issue: N/A. The original PR of `bigdl-llm` is https://github.com/langchain-ai/langchain/pull/17953 
- Dependencies: `ipex-llm` library
- Contribution maintainer: @shane-huang

